### PR TITLE
New Feature: Forcerefresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ There are more [examples] to look at as well.
 | `toolbar`    | boolean  | `false` |       |
 | `top`        | integer  | `0`     |       |
 | `width`      | integer  | `500`   |       |
+| `forcerefresh`|boolean  | `true`  | if popup is still open it will refresh the window. If the user clicked a link and was taken to a different page, they will be taken back to the original page. Likewise, if the user has entered text on a form or performed some action that needed saved, they will lose any unsaved work.
 
 ## License
 

--- a/jquery.popupwindow.js
+++ b/jquery.popupwindow.js
@@ -51,7 +51,6 @@
     var name = options.name || (options.createNew ? 'popup_window_' + random : 'popup_window');
 
     // get existing win handle if exists
-    // would be nice if we could make this persistent
     if (!$.popupWindow.win) { $.popupWindow.win = []; }
     var winPOS = -1;
     for (var i = 0, len = $.popupWindow.win.length; i < len; i++) {
@@ -59,13 +58,19 @@
     }      
 
     // add to global if it didnt already exist
+    var winHref;
     if (winPOS === -1) {
       $.popupWindow.win.push({ name: name, win: { closed: true } });
       winPOS = $.popupWindow.win.length - 1;
+      
+      // try regaining access to the handle
+      $.popupWindow.win[winPOS].win = window.open("", name, paramsJoin);
+      try { winHref = $.popupWindow.win[winPOS].win.location.href; } catch (e) { }
     }
         
     // determine whether to open window
-    if (options.forcerefresh || $.popupWindow.win[winPOS].win.closed) {
+    // the user wants to always refresh, the handle says its closed, the href is a new page
+    if (options.forcerefresh || $.popupWindow.win[winPOS].win.closed || winHref === "about:blank") {
       $.popupWindow.win[winPOS].win = window.open(url, name, params.join(','));
     }
 

--- a/jquery.popupwindow.js
+++ b/jquery.popupwindow.js
@@ -70,7 +70,7 @@
         
     // determine whether to open window
     // the user wants to always refresh, the handle says its closed, the href is a new page
-    if (options.forcerefresh || $.popupWindow.win[winPOS].win.closed || winHref === "about:blank") {
+    if (options.forcerefresh || $.popupWindow.win[winPOS].win.closed || typeof winHref !== "undefined") {
       $.popupWindow.win[winPOS].win = window.open(url, name, params.join(','));
     }
 

--- a/jquery.popupwindow.js
+++ b/jquery.popupwindow.js
@@ -64,7 +64,7 @@
       winPOS = $.popupWindow.win.length - 1;
       
       // try regaining access to the handle
-      $.popupWindow.win[winPOS].win = window.open("", name, paramsJoin);
+      $.popupWindow.win[winPOS].win = window.open("", name, params.join(','));
       try { winHref = $.popupWindow.win[winPOS].win.location.href; } catch (e) { }
     }
         

--- a/jquery.popupwindow.js
+++ b/jquery.popupwindow.js
@@ -70,7 +70,7 @@
         
     // determine whether to open window
     // the user wants to always refresh, the handle says its closed, the href is a new page
-    if (options.forcerefresh || $.popupWindow.win[winPOS].win.closed || typeof winHref !== "undefined") {
+    if (options.forcerefresh || $.popupWindow.win[winPOS].win.closed || winHref === "about:blank") {
       $.popupWindow.win[winPOS].win = window.open(url, name, params.join(','));
     }
 


### PR DESCRIPTION
Proper pull request for a new feature called forcerefresh.

Current behavior:
if popup is still open it will refresh the window. If the user clicked a link and was taken to a different page, they will be taken back to the original page. Likewise, if the user has entered text on a form or performed some action that needed saved, they will lose any unsaved work.

With Forcerefresh:
this will allow users to define if they want to refresh the window should it still exist. This requires them to pass a name for that window, and toggle force refresh off. if they dont want to refresh and it still exists it will simply bring it into focus
