### PR TITLE
Center parent

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ There are more [examples] to look at as well.
 
 | option       | type     | default | notes |
 |--------------|----------|---------|-------|
-| `center`     | boolean  | `true`  | auto-center |
+| `center`     | string   | `'screen'`| possible values are: `'screen'`,`'parent'`, and `null`. For backwards compatibility `true`/`false` is still supported, but deprecated, and may be removed in a future version |
 | `createNew`  | boolean  | `true`  | open a new window, or re-use existing popup |
 | `height`     | integer  | `500`   |       |
 | `left`       | integer  | `0`     |       |

--- a/example.html
+++ b/example.html
@@ -28,7 +28,24 @@
             }
           });
         });
-      })
+        
+        $('a.center-screen').on('click', function(event) {
+          event.preventDefault();
+          $.popupWindow('http://google.com', {
+              width: 400,
+              height: 400,
+              center: 'screen'
+          });
+        });
+
+        $('a.center-parent').on('click', function(event) {
+          event.preventDefault();
+          $.popupWindow('http://google.com', {
+              width: 400,
+              height: 400,
+              center: 'parent'
+          });
+      });
     </script>
   </head>
 
@@ -41,6 +58,8 @@
       <li><a href="#" class="example-defaults">Open window (with defaults)</a></li>
       <li><a href="#" class="example-small">Open window (custom size: 200x200)</a></li>
       <li><a href="#" class="example-callback">Open window (close callback)</a></li>
+      <li><a href="#" class="center-screen">Open window (centered on screen)</a></li>
+      <li><a href="#" class="center-parent">Open window (centered on parent)</a></li>
     </ul>
 
     <h2>More Details</h2>

--- a/jquery.popupwindow.js
+++ b/jquery.popupwindow.js
@@ -5,7 +5,7 @@
 */
 (function($) {
   var defaults = {
-    center:      true,
+    center:      "screen", //true, screen || parent || undefined, null, "", false
     createNew:   true,
     height:      500,
     left:        0,
@@ -25,7 +25,10 @@
     var options = $.extend({}, defaults, opts);
 
     // center the window
-    if (options.center) {
+    if (options.center === "parent") {
+      options.top = window.screenY + Math.round(($(window).height() - options.height) / 2);
+      options.left = window.screenX + Math.round(($(window).width() - options.width) / 2);
+    } else if (options.center === true || options.center === "screen") {
       // 50px is a rough estimate for the height of the chrome above the
       // document area
       options.top = ((screen.height - options.height) / 2) - 50;


### PR DESCRIPTION
Proper pull for centering based on parent.

This allows users to center the pop up based on the browsers window, regardless of monitor. It uses the existing property but changes from boolean to string, while still maintaining backwards support.

Although the existing behavior is to center on `'screen'`, I think you should consider changing the default to center `'parent'`. Most users will not know the difference, and it is more compatible with multiple monitors (see ie bug from #8).
