### PR TITLE
Add object only api

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ minimal chrome.
 $.popupWindow('http://www.google.com', { height: 300, width: 200 });
 ```
 
+### Simple Example with Object as Parameter
+
+Another option is to call `popupWindow` with a single object that contains a url
+key and any other settings. This is functionally the same as the above example
+and is only a stylistic difference.
+
+```
+$.popupWindow({ url: 'http://www.google.com', height: 300, width: 200 });
+```
+
 ### More Examples
 
 There are more [examples] to look at as well.

--- a/example.html
+++ b/example.html
@@ -28,6 +28,14 @@
             }
           });
         });
+        
+        $('.example-objectapi').on('click', function(event) {
+          event.preventDefault();
+          $.popupWindow({
+            url: 'http://google.com'
+          });
+        });
+        
       })
     </script>
   </head>
@@ -41,6 +49,7 @@
       <li><a href="#" class="example-defaults">Open window (with defaults)</a></li>
       <li><a href="#" class="example-small">Open window (custom size: 200x200)</a></li>
       <li><a href="#" class="example-callback">Open window (close callback)</a></li>
+      <li><a href="#" class="example-objectapi">Object API</a></li>
     </ul>
 
     <h2>More Details</h2>

--- a/jquery.popupwindow.js
+++ b/jquery.popupwindow.js
@@ -19,7 +19,7 @@
     toolbar:     false,
     top:         0,
     width:       500,
-    url: ""
+    url:         ""
   };
 
   $.popupWindow = function(url, opts) {

--- a/jquery.popupwindow.js
+++ b/jquery.popupwindow.js
@@ -18,10 +18,15 @@
     status:      false,
     toolbar:     false,
     top:         0,
-    width:       500
+    width:       500,
+    url: ""
   };
 
   $.popupWindow = function(url, opts) {
+    if ($.isPlainObject(url)) {
+      opts = url;
+      url = opts.url;
+    }
     var options = $.extend({}, defaults, opts);
 
     // center the window


### PR DESCRIPTION
Allow user to only pass in an object, with a key for url. This commit maintains backwards 
compatibility.

This is optional, I like passing 1 (potentially complex) object to a function. This is cleaner
in my opinion, and for only a couple of lines I think its should be added in the base project.

I use this by defining a set of defaults I always want to use, then when I'm ready to call the
plugin I extend my setting array with the specifics of that call.

Again, this is purely preference, but I prefer this api, and others may also.
