### PR TITLE
Add force refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ There are more [examples] to look at as well.
 | `toolbar`    | boolean  | `false` |       |
 | `top`        | integer  | `0`     |       |
 | `width`      | integer  | `500`   |       |
+| `forcerefresh`|boolean  | `true`  | If popup is still open it will refresh the window. Any browsing or form field values will be lost, and they will be taken back to the original page. To just bring focus to the existing popup set to `false` and set `name` to a predictable value. Ex. `name:'somename'` |
 
 ## License
 

--- a/example.html
+++ b/example.html
@@ -28,6 +28,21 @@
             }
           });
         });
+        
+        $('.example-namedfocus').on('click', function(event) {
+          event.preventDefault();
+          $.popupWindow('http://google.com', {
+            forcerefresh: false,
+            name: "namedfocus"
+          });
+        });
+        
+        $('.example-namedrefresh').on('click', function(event) {
+          event.preventDefault();
+          $.popupWindow('http://google.com', {
+            name: "namedrefresh"
+          });
+        });
       })
     </script>
   </head>
@@ -41,6 +56,8 @@
       <li><a href="#" class="example-defaults">Open window (with defaults)</a></li>
       <li><a href="#" class="example-small">Open window (custom size: 200x200)</a></li>
       <li><a href="#" class="example-callback">Open window (close callback)</a></li>
+      <li><a href="#" class="example-namedfocus">Open window (named without refresh)</a></li>
+      <li><a href="#" class="example-namedrefresh">Open window (named with refresh)</a></li>
     </ul>
 
     <h2>More Details</h2>


### PR DESCRIPTION
To allow users to bring focus to an existing popup without causing the window to refresh.

Current behavior:
Clicking on a link to open a pop up that happens to already exist will cause that window
to refresh. This has the potential for users to lose unsaved work, or lose the current
URL if it was different from the initial one they were presented with.

I chose the name `forcerefresh` to define this current behavior. In my opinion this should
be defaulted to false, but in order to maintain backwards compatibility I set it to true.
With `forcerefresh` disabled it will allow users to just have the pop up brought into focus
without the refresh if it exists. If it doesn't exist, the pop up will be created and given 
focus. 

In order to use this feature to work the user needs to pass a name for that window, and toggle
`forcerefresh` off.

An example of use:
With a help desk system, users may need to be working on multiple tickets simultaneously.
With this requirement a modal is out of the question. If a user clicks on a ticket link in the 
main window a pop up is displayed, which will allow users to modify its contents. Using
`forcerefresh:false` the developer can ensure that when the user clicks on that same 
ticket link they will be presented with the existing pop up but without losing any modifications
they have completed, but not saved.

An alternative:
I've create an alternative in #13. Check that out and determine which you would like to inlcude.
