### PR TITLE
Add force refresh (alt version)

### DIFF
--- a/jquery.popupwindow.js
+++ b/jquery.popupwindow.js
@@ -18,7 +18,8 @@
     status:      false,
     toolbar:     false,
     top:         0,
-    width:       500
+    width:       500,
+    forcerefresh:true
   };
 
   $.popupWindow = function(url, opts) {
@@ -45,10 +46,24 @@
     params.push('left=' + options.left);
     params.push('top=' + options.top);
 
-    // open window
+    // define name
     var random = new Date().getTime();
     var name = options.name || (options.createNew ? 'popup_window_' + random : 'popup_window');
-    var win = window.open(url, name, params.join(','));
+    
+    // try regaining access to a window handle, will fail for different origin
+    var winHref;
+    var win = window.open("", name, params.join(','));
+    try { winHref = win.location.href; } catch (e) { }
+    
+    // determine whether to open window
+    // the user wants to always refresh, the href is a new page
+    // winHref could be 3 possible values
+    // 1. undefined - this failed grabbing url, meaning it exists, but on different origin - dont reload url
+    // 2. some url - this passed the assignment above, must be same origin - dont reload url
+    // 3. about:blank - the window didnt exist and the user now has a blank window - reload url
+    if (options.forcerefresh || winHref === "about:blank") {
+      win = window.open(url, name, params.join(','));
+    }
 
     // unload handler
     if (options.onUnload && typeof options.onUnload === 'function') {


### PR DESCRIPTION
This is a slimmer implementation which doesn't keep a global list of open window handles.
The downside to not having a local array of handles, specifically in chrome, is that it 
loses its original handle, and although it semi regains it, it is no longer seen as the parent.

With #12 you will get this behavior when the main page is reloaded. But under normal use
you will still be seen as the parent.

In #12 I define a global array of window handles that gets attached to the $.popupWindow
object. I believe this adds speed and is cleaner. However, its not necessary in order to regain a
reference to an existing pop up. 

See #12 for all the other details.
