### PR TITLE
Add support for percentage syntax for width and height options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ There are more [examples] to look at as well.
 |--------------|----------|---------|-------|
 | `center`     | string   | `'screen'`| possible values are: `'screen'`,`'parent'`, and `null`. For backwards compatibility `true`/`false` is still supported, but deprecated, and may be removed in a future version |
 | `createNew`  | boolean  | `true`  | open a new window, or re-use existing popup |
-| `height`     | integer  | `500`   |       |
+| `height`     | integer  | `500`   | see `'width'` for syntax notes |
 | `left`       | integer  | `0`     |       |
 | `location`   | boolean  | `false` |       |
 | `menubar`    | boolean  | `false` |       |
@@ -76,7 +76,7 @@ There are more [examples] to look at as well.
 | `status`     | boolean  | `false` |       |
 | `toolbar`    | boolean  | `false` |       |
 | `top`        | integer  | `0`     |       |
-| `width`      | integer  | `500`   |       |
+| `width`      | integer  | `500`   | percentages supported too using syntax `'80% of screen'` or `'80% of parent'` or `'80%'` |
 
 ## Notes
 

--- a/jquery.popupwindow.js
+++ b/jquery.popupwindow.js
@@ -23,12 +23,33 @@
 
   $.popupWindow = function(url, opts) {
     var options = $.extend({}, defaults, opts);
+    
+    // support deprecated boolean center value
+    if (options.center === true) {
+      options.center = "screen";
+    }
+  
+    // Convert percentage height (e.g. "80%" or "80% of parent" or "80% of screen") into pixel height.
+    if ((typeof(options.height) == 'string') && options.height.match(/^(\d+)%(\s+of\s+(screen|opener|parent|window))?$/)) {
+      var percent = parseInt(RegExp.$1);
+      var of_what = RegExp.$3 ? RegExp.$3 : (options.center ? options.center : 'screen');
+      var of_height = of_what == 'screen' ? screen.height : $(window).height();
+      options.height = Math.round(percent * of_height / 100);
+    }
+  
+    // Convert percentage width (e.g. "80%" or "80% of parent" or "80% of screen") into pixel width.
+    if ((typeof(options.width) == 'string') && options.width.match(/^(\d+)%(\s+of\s+(screen|opener|parent|window))?$/)) {
+      var percent = parseInt(RegExp.$1);
+      var of_what = RegExp.$3 ? RegExp.$3 : (options.center ? options.center : 'screen');
+      var of_width = of_what == 'screen' ? screen.width : $(window).width();
+      options.width = Math.round(percent * of_width / 100);
+    }
 
     // center the window
     if (options.center === "parent") {
       options.top = window.screenY + Math.round(($(window).height() - options.height) / 2);
       options.left = window.screenX + Math.round(($(window).width() - options.width) / 2);
-    } else if (options.center === true || options.center === "screen") {
+    } else if (options.center === "screen") {
       // 50px is a rough estimate for the height of the chrome above the
       // document area
       


### PR DESCRIPTION
Now you can use percentage strings as values for width and height, e.g.:
"80%"
or
"80% of screen"
or
"80% of parent"
To calculate the absolute width/height, the code needs to know percentage of what.
If no "of" is specified, then the string in the option "center" is assumed if set, else it assumes "screen".